### PR TITLE
Add mypy typings to project compatible with python 3.10 + run unit tests in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           mkdir dist
           python make_wheels.py
-      - name: Show built files
+      - name: Show built wheels
         run: |
             ls -l dist/*
       - name: Type Checking
@@ -89,5 +89,5 @@ jobs:
         run:
             python -m nodejs --version
             python -m nodejs.npm --version
-
-
+            python -m nodejs.npx --version
+            python -m nodejs.corepack --version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,16 @@ jobs:
       - name: Show built files
         run: |
             ls -l dist/*
+      - name: Type Checking
+        run: |
+          python -m mypy
+      - name: Tests
+        run: |
+          for wheel in $(find dist -name "*manylinux*_x86_64.whl"); do
+            echo "Testing installation with wheel: ${wheel}"
+            pip install ${wheel}
+            python -m pytest
+          done
       - uses: actions/upload-artifact@v3
         with:
             name: nodejs-pip-wheels

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ nodejs-cmd/*.egg-info
 env*/
 __pycache__/
 *.py[cod]
+venv
+node_modules
+package-lock.json
+package.json

--- a/make_wheels.py
+++ b/make_wheels.py
@@ -1,5 +1,6 @@
 import os
 import hashlib
+import platform
 import urllib.request
 import urllib.error
 from typing import Dict, List, Any
@@ -8,6 +9,14 @@ from email.message import EmailMessage
 from wheel.wheelfile import WheelFile
 from zipfile import ZipInfo, ZIP_DEFLATED
 from inspect import cleandoc
+
+# To support our internal typings, we require Python3.10+, but to KISS
+# for now we only support building this project with Python3.10 (this is
+# a developer only requirement)
+(python_major, python_minor, _python_patch) = platform.python_version_tuple()
+if not (python_major == '3' and python_minor == '10'):
+    breakpoint()
+    raise Exception(f"This build script is expected to run on Python 3.10, but you are using {platform.python_version()}")
 
 
 # Versions to build if run as a script:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,27 @@
+[mypy]
+
+files = **/*.py
+
+exclude = (?x)(
+    venv
+  )
+
+check_untyped_defs = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True
+disallow_any_unimported = True
+warn_return_any = True
+warn_unused_ignores = True
+show_error_codes = True
+enable_error_code = ignore-without-code
+follow_imports = normal
+
+[mypy-libarchive]
+ignore_missing_imports = True
+
+[mypy-wheel.*]
+ignore_missing_imports = True
+
+[mypy-nodejs]
+ignore_missing_imports = True

--- a/nodejs-cmd/nodejs_cmd.py
+++ b/nodejs-cmd/nodejs_cmd.py
@@ -1,10 +1,10 @@
 from nodejs import node, npm, npx
 
-def node_main():
+def node_main() -> None:
     node.main()
 
-def npm_main():
+def npm_main() -> None:
     npm.main()
 
-def npx_main():
+def npx_main() -> None:
     npx.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-wheel
+wheel < 0.38
 twine
 libarchive-c
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-wheel < 0.38
+wheel
 twine
 libarchive-c
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ wheel
 twine
 libarchive-c
 pytest
+typing-extensions
+mypy
+types-setuptools

--- a/tests/test_comand_line.py
+++ b/tests/test_comand_line.py
@@ -1,61 +1,63 @@
 "Test nodejs command line"
 
 import os, sys, subprocess
+import pathlib
+from pytest import CaptureFixture
 
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_runs():
+def test_runs() -> None:
     assert subprocess.call([sys.executable, "-m", "nodejs", "--version"]) == 0
 
 
-def test_version(capfd):
+def test_version(capfd: CaptureFixture) -> None:
     subprocess.call([sys.executable, "-m", "nodejs", "--version"])
     out, err = capfd.readouterr()
     assert out.startswith('v')
 
 
-def test_eval(capfd):
+def test_eval(capfd: CaptureFixture) -> None:
     subprocess.call([sys.executable, "-m", "nodejs", "--eval", "console.log('hello')"])
     out, err = capfd.readouterr()
     assert out.strip() == 'hello'
 
 
-def test_eval_error(capfd):
+def test_eval_error(capfd: CaptureFixture) -> None:
     subprocess.call([sys.executable, "-m", "nodejs", "--eval", "console.error('error')"])
     out, err = capfd.readouterr()
     assert err.strip() == 'error'
 
 
-def test_eval_error_exit():
+def test_eval_error_exit() -> None:
     ret = subprocess.call([sys.executable, "-m", "nodejs", "--eval", "process.exit(1)"])
     assert ret == 1
 
 
-def test_script(capfd):
+def test_script(capfd: CaptureFixture) -> None:
     subprocess.call([sys.executable, "-m", "nodejs", os.path.join(THIS_DIR, "test_node", "test_script.js")])
     out, err = capfd.readouterr()
     assert out.strip() == 'hello'
 
 
-def test_args(capfd):
+def test_args(capfd: CaptureFixture) -> None:
     subprocess.call([sys.executable, "-m", "nodejs", os.path.join(THIS_DIR, "test_node", "test_args.js"), "hello"])
     out, err = capfd.readouterr()
     assert out.strip() == 'hello'
 
 
-def test_npm_runs():
+def test_npm_runs() -> None:
     assert subprocess.call([sys.executable, "-m", "nodejs.npm", "--version"]) == 0
 
 
-def test_npm_version(capfd):
+def test_npm_version(capfd: CaptureFixture) -> None:
     subprocess.call([sys.executable, "-m", "nodejs.npm", "--version"])
     out, err = capfd.readouterr()
     assert isinstance(out, str)
 
 
-def test_install_package(tmp_path, capfd):
+def test_install_package(tmp_path: pathlib.Path, capfd: CaptureFixture) -> None:
     os.chdir(tmp_path)
     subprocess.call([sys.executable, "-m", "nodejs.npm", "init", "-y"])
     assert (tmp_path / 'package.json').exists()

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,22 +1,23 @@
 "Test nodejs.node"
 
 import os
+from pytest import CaptureFixture
 
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_package_installed():
+def test_package_installed() -> None:
     import nodejs
     assert nodejs.__version__ is not None
 
 
-def test_runs():
+def test_runs() -> None:
     from nodejs import node
     assert node.call(['--version']) is 0
 
 
-def test_version(capfd):
+def test_version(capfd: CaptureFixture) -> None:
     from nodejs import node, node_version
     node.call(['--version'])
     out, err = capfd.readouterr()
@@ -24,34 +25,34 @@ def test_version(capfd):
     assert out.strip() == f'v{node_version}'
 
 
-def test_eval(capfd):
+def test_eval(capfd: CaptureFixture) -> None:
     from nodejs import node
     node.call(['--eval', 'console.log("hello")'])
     out, err = capfd.readouterr()
     assert out.strip() == 'hello'
 
 
-def test_eval_error(capfd):
+def test_eval_error(capfd: CaptureFixture) -> None:
     from nodejs import node
     node.call(['--eval', 'console.error("error")'])
     out, err = capfd.readouterr()
     assert err.strip() == 'error'
 
 
-def test_eval_error_exit():
+def test_eval_error_exit() -> None:
     from nodejs import node
     ret = node.call(['--eval', 'process.exit(1)'])
     assert ret == 1
 
 
-def test_script(capfd):
+def test_script(capfd: CaptureFixture) -> None:
     from nodejs import node
     node.call([os.path.join(THIS_DIR, 'test_node', 'test_script.js')])
     out, err = capfd.readouterr()
     assert out.strip() == 'hello'
 
 
-def test_args(capfd):
+def test_args(capfd: CaptureFixture) -> None:
     from nodejs import node
     node.call([os.path.join(THIS_DIR, 'test_node', 'test_args.js'), 'hello'])
     out, err = capfd.readouterr()

--- a/tests/test_npm.py
+++ b/tests/test_npm.py
@@ -1,23 +1,25 @@
 "Test nodejs.npm"
 
 import os
+import pathlib
+from pytest import CaptureFixture
 
 
-def test_runs():
+def test_runs() -> None:
     from nodejs import npm
     assert npm.call(['--version']) is 0
 
 
-def test_version(capfd):
+def test_version(capfd: CaptureFixture) -> None:
     from nodejs import npm
     npm.call(['--version'])
     out, err = capfd.readouterr()
     assert isinstance(out, str)
 
 
-def test_install_package(tmp_path, capfd):
+def test_install_package(tmp_path: pathlib.Path, capfd: CaptureFixture) -> None:
     from nodejs import npm, node
-    import json
+    
     os.chdir(tmp_path)
     npm.call(['init', '-y'])
     assert (tmp_path / 'package.json').exists()


### PR DESCRIPTION
This PR adds `mypy` type checking to all of our _internal_ code -- whereas #8 added typing for our _external_ code

I used pretty modern type syntax, therefore this PR now requires project developers (and our release machinery) to use Python 3.10 specifically (though really we could support 3.10+, I wanted to KISS for now)